### PR TITLE
Fixed source-map passed to istanbul-lib-instrument not being a plain object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,13 @@ export default function(this: loader.LoaderContext, source: string, sourceMap?: 
 
   // Instrument the code
   let instrumenter = createInstrumenter(options);
-  instrumenter.instrument(source, this.resourcePath, done.bind(this), sourceMap);
+  if (sourceMap !== undefined) {
+    const { ...sourceMapPlainObject } = sourceMap;
+    instrumenter.instrument(source, this.resourcePath, done.bind(this), sourceMapPlainObject);
+  }
+  else {
+    instrumenter.instrument(source, this.resourcePath, done.bind(this), undefined);
+  }
 
   function done(this: loader.LoaderContext, error: Error | null, instrumentedSource: string) {
     // Get the source map for the instrumented code


### PR DESCRIPTION
Hi,
I stumbled upon this issue while trying to instrument code previously compiled with svelte. The resulting source-map was an instance of `SourceMap`, not a plain object. This led me to babel/babel#11614 and eventually to [istanbuljs/istanbuljs#576](https://github.com/istanbuljs/istanbuljs/pull/576#issuecomment-778256725) where it was stated that `istanbul-lib-instrument` expects the source map to be a plain object - something which this plugin does not make sure of. This PR fixes that and makes the source-map always be a plain object.
